### PR TITLE
use OPENAI_API_KEY if available prior to local file

### DIFF
--- a/hey/aichat.py
+++ b/hey/aichat.py
@@ -29,9 +29,19 @@ def get_dollars(additional_tokens):
 def get_tokens_available(additional_tokens = ""):
     return max_tokens() - get_tokens(additional_tokens)
 
-def find_openai_key():
+def get_openai_key_path():
     home_path = os.path.expanduser("~")    
-    openai.api_key_path = os.path.join(home_path,".openai.apikey")
+    return os.path.join(home_path,".openai.apikey")
+
+def setup_openai_key():
+    # detect if the key is already set (openai package read it by default)
+    apikey = os.environ.get("OPENAI_API_KEY")
+    if apikey:
+        return True
+    # if no key is set, try to read it from a file
+    key = get_openai_key_path()
+    openai.api_key_path = key
+    return os.path.exists(key)
 
 def clear():
     global messages

--- a/hey/cli.py
+++ b/hey/cli.py
@@ -244,7 +244,7 @@ def main():
     global prompt
     colorama.init()
 
-    hey.aichat.find_openai_key()
+    hey.aichat.setup_openai_key()
 
     user_input = get_initial_arguments()
 

--- a/hey/install.py
+++ b/hey/install.py
@@ -2,7 +2,7 @@ import os
 import glob
 from prompt_toolkit import prompt
 
-from hey.aichat import find_openai_key
+from hey.aichat import setup_openai_key, get_openai_key_path
 from termcolor import colored
 
 def install(force=False):
@@ -13,16 +13,16 @@ def install(force=False):
     program_path = os.path.dirname(__file__)
 
     # Check for openai key
-    openai_key_path = os.path.join(home_path, ".openai.apikey")
-
-    if not os.path.exists(openai_key_path):
+    if not setup_openai_key():
+        openai_key_path = get_openai_key_path()
         print(colored("* No OpenAI key found at " + openai_key_path, 'light_grey'))
 
         api_key = prompt("Please enter your OpenAI key: ")
         with open(openai_key_path, "w") as f:
             f.write(api_key)
 
-    find_openai_key()
+        # update the key
+        setup_openai_key()
 
     if not os.path.exists(hey_path):
         print(colored("* Creating " + hey_path, 'light_grey'))


### PR DESCRIPTION
By default, openai package use an `OPENAI_API_KEY` environment key. If a such setup is done, there is no need for a local file.

This PR intend to change the behavior for preferring the environment variable if available